### PR TITLE
Fixed GTranslate in navbar + the selector only displays 2 letters

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
     <script src="public/js/fluidEffect/fluid.min.js"></script>
 
     <!-- Translate related -->
-    <script>window.gtranslateSettings = {"default_language":"en","native_language_names":true,"detect_browser_language":true,"languages":["en","ar","es","fr","de"],"wrapper_selector":".gtranslate_wrapper"}</script>
+    <script>window.gtranslateSettings = {"default_language":"en","native_language_names":false,"detect_browser_language":true,"languages":["en","ar","es","fr","de"],"wrapper_selector":".gtranslate_wrapper"}</script>
     <script src="https://cdn.gtranslate.net/widgets/latest/dropdown.js" defer></script>
 
     <!-- Intial Scroll When Reloading -->
@@ -141,6 +141,9 @@
           <li><a href="#">Collections</a></li>
           <li><a href="#">Gifting</a></li>
           <li><a href="public/pages/our-story.html">Our Story</a></li>
+
+        <!-- Translate -->
+        <div class="gtranslate_wrapper"></div>
         </ul>
       </div>
     </nav>

--- a/public/css/navBar.css
+++ b/public/css/navBar.css
@@ -32,7 +32,7 @@ nav.nav-visible {
 nav .left-container {
   display: flex;
   align-items: center;
-  gap: 20px;
+  gap: 35px;
   order: 1;
   position: absolute;
   left: 20px;
@@ -82,16 +82,16 @@ nav .gtranslate_wrapper select,
 nav .gtranslate_wrapper .gt_selector {
   font-family: inherit;
   font-size: 14px;
-  text-transform: none;
+  text-transform: uppercase;
   font-weight: normal;
   color: #000;
   background: transparent;
   border: none;
   padding: 0;
   cursor: pointer;
-  max-width: 90%;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  width: 5ch;
+  text-overflow: clip;
+  letter-spacing: 1px;
 }
 
 nav .gtranslate_wrapper select option {
@@ -108,6 +108,11 @@ nav .links {
   display: flex;
   justify-content: center;
   margin-left: 20px;
+}
+
+/* Hide translate in mobile links by default */
+nav .links .gtranslate_wrapper {
+  display: none;
 }
 
 /* Navigation links */
@@ -219,9 +224,9 @@ nav .mobile-logo img {
   }
 
   nav .links .gtranslate_wrapper {
+    display: block; /* Show translate in mobile links */
     opacity: 1;
     visibility: visible;
-    
   }
 
   ul > .mobile-logo {


### PR DESCRIPTION
except the (English or Spanish meme) - actually the Spanish one fsr has a 'kasra' under it