### PR TITLE
now you can send html in the email

### DIFF
--- a/public/js/checkout.js
+++ b/public/js/checkout.js
@@ -63,12 +63,22 @@ document.addEventListener("DOMContentLoaded", function () {
     cardNameDisplay.textContent = cleanedName || "PREM KUMAR SHAHI";
   }
 
-  function updateCardExpiry() {
-    let value = cardExpiryInput.value.replace(/\D/g, "");
-    if (value.length > 2) value = value.slice(0, 2) + "/" + value.slice(2, 4);
-    cardExpiryInput.value = value.slice(0, 5);
-    cardExpiryDisplay.textContent = cardExpiryInput.value || "05/28";
+function updateCardExpiry() {
+  let value = cardExpiryInput.value.replace(/\D/g, "");  // Remove non-digit characters
+  // If the value length is more than 2, insert a slash between month and year
+  if (value.length > 2) {
+    value = value.slice(0, 2) + "/" + value.slice(2, 4);
   }
+  // If the month is greater than 12, set it to 12
+  const month = parseInt(value.slice(0, 2), 10);
+  if (month > 12) {
+    value = "12" + value.slice(2);  // Limit the month to 12
+  }
+  // Limit the input to 5 characters (MM/YY)
+  cardExpiryInput.value = value.slice(0, 5);
+  // Update the display with the current expiry value or default
+  cardExpiryDisplay.textContent = cardExpiryInput.value || "05/28";
+}
 
   function updateCardCVV() {
     let digitsOnly = cardCVVInput.value.replace(/\D/g, "").slice(0, 3);

--- a/utilities/emailService.js
+++ b/utilities/emailService.js
@@ -1,7 +1,7 @@
 import nodemailer from "nodemailer";
 import { EMAIL_USER, EMAIL_PASS } from "../config/secrets.js";
 
-export default async function sendEmail({ to, subject, text }) {
+export default async function sendEmail({ to, subject, text, html }) {
   try {
     const transporter = nodemailer.createTransport({
       service: "gmail",
@@ -15,7 +15,8 @@ export default async function sendEmail({ to, subject, text }) {
       from: EMAIL_USER,
       to,
       subject,
-      text,
+      text,  // This will be the plain text version of the email (fallback)
+      html,  // This will be the HTML version of the email
     };
 
     transporter.sendMail(mailOptions, (error, info) => {


### PR DESCRIPTION
### **User description**
Description & Notes
📝 Briefly describe the changes/notes in this PR.


___

### **PR Type**
enhancement


___

### **Description**
- Added HTML email support in `sendEmail` utility

- Improved card expiry input validation in checkout form


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>emailService.js</strong><dd><code>Add HTML support to email sending utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

utilities/emailService.js

<li>Updated <code>sendEmail</code> to accept an <code>html</code> parameter.<br> <li> Modified mail options to include both <code>text</code> and <code>html</code> fields.<br> <li> Enables sending HTML-formatted emails.


</details>


  </td>
  <td><a href="https://github.com/mohamedelziat50/Aloura-MIU/pull/331/files#diff-2e4e6b97b5fa71ff71d431e94b31bd4c3edce06ac5419cbb891b72112f9d4901">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>checkout.js</strong><dd><code>Improve card expiry input validation and formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

public/js/checkout.js

<li>Enhanced card expiry input to limit month to 12.<br> <li> Improved formatting and validation for expiry field.<br> <li> Added inline comments for clarity.


</details>


  </td>
  <td><a href="https://github.com/mohamedelziat50/Aloura-MIU/pull/331/files#diff-975659977d34784862c8514d88950f3c8c7d9f8b85e78804135b35b01add58ca">+15/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>