### PR TITLE
fixed the proifle picture in the orderviewpage

### DIFF
--- a/views/admin/viewOrder.ejs
+++ b/views/admin/viewOrder.ejs
@@ -467,9 +467,9 @@
               <div class="col-md-4">
                 <div class="border rounded-3 p-3 h-100 bg-white">
                   <div class="d-flex align-items-center mb-2">
-                    <% if(order.user && order.user.profilePicture) { %>
+                    <% if(order.user && order.user.profilePic) { %>
                     <img
-                      src="<%= order.user.profilePicture %>"
+                      src="<%= order.user.profilePic%>"
                       alt="User Profile Picture"
                       class="rounded-circle me-2"
                       style="


### PR DESCRIPTION
### **User description**
Description & Notes
📝 Briefly describe the changes/notes in this PR.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed incorrect user profile picture variable in order view page

- Updated image source and conditional check to use `profilePic`


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>viewOrder.ejs</strong><dd><code>Correct user profile picture variable in order view</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

views/admin/viewOrder.ejs

<li>Changed user profile picture variable from <code>profilePicture</code> to <br><code>profilePic</code><br> <li> Updated both the conditional check and image source accordingly


</details>


  </td>
  <td><a href="https://github.com/mohamedelziat50/Aloura-MIU/pull/367/files#diff-74ba46589b318390c80271f08fa78b7293925898713f63ed3fe95e264d23ebf5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>